### PR TITLE
Minor language update for exempt admin

### DIFF
--- a/src/modules/Captcha/templates/admin/modifyconfig.tpl
+++ b/src/modules/Captcha/templates/admin/modifyconfig.tpl
@@ -19,7 +19,7 @@
 			<input type="text" value="{$modvars.Captcha.publickey}" id="publickey" name="publickey" />
         </div>
         <div class="z-formrow">
-			<label for="exemptAdmin">{gt text='Exempt admin from captcha requirement'}</label>
+			<label for="exemptAdmin">{gt text='Exclude users with Captcha admin permission from captcha validation'}</label>
 			<input type="checkbox" value="1" id="exemptAdmin" name="exemptAdmin"{if $modvars.Captcha.exemptAdmin eq true} checked="checked"{/if}/>
         </div>
         <div class="z-formrow">


### PR DESCRIPTION
I have update the text a bit exempt=>exclude and made clearer that it concerns users with Captch ADMIN permission that are excluded. "The" admin is a bit unspecified.
